### PR TITLE
Switch build to ES modules

### DIFF
--- a/dist/calculator.js
+++ b/dist/calculator.js
@@ -15,8 +15,9 @@ class Calculator {
     }
     calculate() {
         try {
-            // Using eval for simplicity; in production you may want a safer parser
-            this.display.value = eval(this.display.value).toString();
+            // Use mathjs for safe mathematical expression evaluation
+            const result = math.evaluate(this.display.value);
+            this.display.value = result.toString();
         }
         catch (_a) {
             this.display.value = 'Error';

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
     </div>
   </div>
 
-  <script src="dist/calculator.js"></script>
+  <script src="node_modules/mathjs/lib/browser/math.js"></script>
+  <script type="module" src="dist/calculator.js"></script>
 </body>
 </html>

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -1,4 +1,4 @@
-import * as math from 'mathjs';
+declare const math: any;
 
 class Calculator {
   private display: HTMLInputElement;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "es2015",
     "strict": true,
     "outDir": "dist"
   }


### PR DESCRIPTION
## Summary
- compile TypeScript using ES modules
- load math.js from `node_modules` in the browser
- adjust source to rely on global `math`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c0a27063483209472cf0c834e1465